### PR TITLE
Corrected typo for Publisher entity to hold 'writers' instead of 'rea…

### DIFF
--- a/docs/entities.rst
+++ b/docs/entities.rst
@@ -18,7 +18,7 @@ Participants
     Participants can hold any number of Publishers and/or Subscribers
 
 Publisher
-    Publishers can hold any number of data readers.
+    Publishers can hold any number of data writers.
 
 Subscriber
     Subscribers can hold any number of data readers.


### PR DESCRIPTION
The entities.rst documentation page had an error in referring to Publishers holding any number of data "readers" and should state holding any number of "writers".